### PR TITLE
fix: buildQuery func sometimes creates SQL incorrectly

### DIFF
--- a/src/service/issue-service.ts
+++ b/src/service/issue-service.ts
@@ -6,6 +6,7 @@ import { JqlService } from "./jql-service";
 /**
  * Service class to handle operations related to Issues.
  */
+let globalIndex = 0
 export class IssueService {
   private _jqlService: JqlService;
   private _issueRepository: Repository<Issue>;
@@ -83,7 +84,7 @@ export class IssueService {
    */
   private buildQuery(qb: any, conditions: any[], parentOperator: string = "AND") {
     // Iterate over each condition in the conditions array
-    conditions.forEach((condition, index) => {
+    conditions.forEach((condition) => {
       // If the condition is a logical operator, update the parentOperator
       if (condition.operator === "AND" || condition.operator === "OR" || condition.operator === "NOT") {
         parentOperator = condition.operator;
@@ -103,17 +104,18 @@ export class IssueService {
           throw new Error(`Unknown operator for field: ${field}`);
         }
         // Get the SQL condition string based on the field, operator, and values
-        const sqlCondition = this.getSqlCondition(field, operator, values, index);
+        const sqlCondition = this.getSqlCondition(field, operator, values, globalIndex);
         // Add the SQL condition to the query builder with the appropriate operator
         if (operator === "IN") {
           qb[parentOperator === "AND" ? "andWhere" : "orWhere"](sqlCondition, {
-            [`values${index}`]: values,
+            [`values${globalIndex}`]: values,
           });
         } else {
           qb[parentOperator === "AND" ? "andWhere" : "orWhere"](sqlCondition, {
-            [`value${index}`]: values[0],
+            [`value${globalIndex}`]: values[0],
           });
         }
+        globalIndex++
       }
     });
   }


### PR DESCRIPTION
**Problem Description**
The current implementation of JQL parsing sometimes results in incorrect SQL generation. Specifically, the status in the generated SQL does not match the intended JQL status.

Example JQL:

```sql
status = "Unreviewed" AND (priority = "High" OR priority = "Medium") AND assignee IS NOT NULL ORDER BY created_at DESC, updated_at ASC
```

Initial Output from qb.getQueryAndParameters():
```
QUERY: [
  'SELECT "Issue"."id" AS "Issue_id", "Issue"."title" AS "Issue_title", "Issue"."description" AS "Issue_description", "Issue"."status" AS "Issue_status", "Issue"."assignee" AS "Issue_assignee", "Issue"."priority" AS "Issue_priority", "Issue"."label" AS "Issue_label", "Issue"."resolved" AS "Issue_resolved", "Issue"."created_at" AS "Issue_created_at", "Issue"."updated_at" AS "Issue_updated_at" FROM "Issue" "Issue" WHERE issue.status = $1 AND (issue.priority = $1 OR issue.priority = $2) AND issue.assignee IS NOT NULL ORDER BY issue.created_at DESC, issue.updated_at ASC', 
  [ 'High', 'Medium' ]
]
```

In this output, the status according to JQL should be "Unreviewed", but the generated SQL incorrectly references the first value in the parameters array, which is 'High'. As a result, the SQL query becomes:

```sql
... WHERE issue.status = High AND (issue.priority = High OR issue.priority = Medium)
```

This should instead be:
```sql
WHERE issue.status = Unreviewed AND (issue.priority = High OR issue.priority = Medium)
```

**Root Cause**
The issue arises from how the ```buildQuery``` function handles the indexing of conditions when it recursively unpacks itself. During the iteration over a 'group' array, it incorrectly applies the index to the parameters.

Example Group Array:

```json
{
  "group": [
    { "field": "priority", "operator": "=", "values": ["High"] },
    { "operator": "OR" },
    { "field": "priority", "operator": "=", "values": ["Medium"] }
  ]
}
```

When iterating over this array, the function starts from index 0 again and attempts to apply it to the query builder, resulting in an error (it's because you've already applied 0 earlier).

**Proposed Solution**
Introduce a global index that tracks the current position in the parameters array.
Use this global index consistently throughout the parsing process to ensure that the correct values are referenced.

Result after the fix:

```
[+] QUERY:
 [
  'SELECT "Issue"."id" AS "Issue_id", "Issue"."title" AS "Issue_title", "Issue"."description" AS "Issue_description", "Issue"."status" AS "Issue_status", "Issue"."assignee" AS "Issue_assignee", "Issue"."priority" AS "Issue_priority", "Issue"."label" AS "Issue_label", "Issue"."resolved" AS "Issue_resolved", "Issue"."created_at" AS "Issue_created_at", "Issue"."updated_at" AS "Issue_updated_at" FROM "Issue" "Issue" WHERE issue.status = $1 AND (issue.priority 
= $2 OR issue.priority = $3) AND issue.assignee IS NOT NULL ORDER BY issue.created_at DESC, issue.updated_at ASC', 
  [ 'Unreviewed', 'High', 'Medium' ]
]
```